### PR TITLE
"Illegal member variable name" error

### DIFF
--- a/ASolrQueryResponse.php
+++ b/ASolrQueryResponse.php
@@ -122,10 +122,10 @@ class ASolrQueryResponse extends CComponent {
 		}
 		foreach($this->getSolrObject()->facet_counts as $facetType => $item) {
 			foreach($item as $facetName => $values) {
-				if (is_object($values)) {
+				if (@is_object($values)) {
 					$values = (array) $values;
 				}
-				elseif (!is_array($values)) {
+				elseif (!@is_array($values)) {
 					$values = array("value" => $values);
 				}
 				$facet = new ASolrFacet($values);

--- a/ASolrQueryResponse.php
+++ b/ASolrQueryResponse.php
@@ -122,6 +122,8 @@ class ASolrQueryResponse extends CComponent {
 		}
 		foreach($this->getSolrObject()->facet_counts as $facetType => $item) {
 			foreach($item as $facetName => $values) {
+				/* Using @ to suppress weird errors
+				 * "Illegal member variable name" */
 				if (@is_object($values)) {
 					$values = (array) $values;
 				}


### PR DESCRIPTION
Hello,

For some reason I was keep getting a weird PHP notice 
stating `Illegal member variable name` when requesting some field facets.

Specifically it was about `/extensions/solr/ASolrQueryResponse.php(125)` where 
`if (is_object($values)) {` checks if it's an object.

After talk with Charles I did CVarDump $values before the check and the correct results were shown. It must be some deeper issue through pecl solr. 

Let me know if you want any changes.
Thanks
