### PR TITLE
Issue with attributeNames() method called on instances create by ASolrDocument::model()

### DIFF
--- a/tests/ASolrDocumentTest.php
+++ b/tests/ASolrDocumentTest.php
@@ -29,6 +29,15 @@ class ASolrDocumentTest extends CTestCase {
 		$this->assertEquals(array("name","incubationdate_dt"),$doc->attributeNames());
 	}
 	/**
+	 * Tests the attributeNames() method in a ASolrDocument::model() instance
+	 */
+	public function testAttributeNamesFromStaticModelMethod() {
+		$doc = ExampleExtendedSolrDocument::model();
+		$this->assertEquals(array("incubationdate_dt"),$doc->attributeNames());
+		$doc->name = "test item";
+		$this->assertEquals(array("name","incubationdate_dt"),$doc->attributeNames());
+	}
+	/**
 	 * Tests the primary key methods
 	 */
 	public function testPrimaryKey() {


### PR DESCRIPTION
Hello,

I'm having some trouble with new instances of objects created with the static ASolrDocument::model(). I created a test to verify what I'm seeing. When I run `testAttributeNamesFromStaticModelMethod()` I get the following error:

```
PHP Fatal error:  Call to a member function toArray() on a non-object in ASolrDocument.php on line 127

Fatal error: Call to a member function toArray() on a non-object in ASolrDocument.php on line 127
```

It looks like the `init()` method doesn't get run when you create an object in this way? Any help would be appreciated.

Thanks!
nikhil
